### PR TITLE
chore(lint-make): added semicolon rule for linter, and silent makefile flags

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -31,6 +31,7 @@
                 "selector": "TSEnumDeclaration",
                 "message": "Don't declare enums use type instead"
             }
-        ]
+        ],
+        "semi": [2, "always"]
     }
 }

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 ## declare PHONY
 .PHONY: build test
+MAKEFLAGS += --silent
 
 NODE_BIN=node_modules/.bin/
 


### PR DESCRIPTION
chore(lint-make): added semicolon rule for linter, and silent makefile flags